### PR TITLE
docs(HomeProxy): add clarification

### DIFF
--- a/contracts/src/0.8/RealitioHomeProxyArbitrum.sol
+++ b/contracts/src/0.8/RealitioHomeProxyArbitrum.sol
@@ -28,7 +28,8 @@ contract RealitioHomeProxyArbitrum is IHomeArbitrationProxy {
 
     /// @dev The address of the Realitio contract (v3.0 required). TRUSTED.
     IRealitio public immutable realitio;
-    address public immutable foreignProxy; // Address of the proxy on L1.
+    /// @dev Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
+    address public immutable foreignProxy;
     /// @dev ID of the foreign chain, required for Realitio.
     bytes32 public immutable foreignChainId;
 
@@ -67,7 +68,7 @@ contract RealitioHomeProxyArbitrum is IHomeArbitrationProxy {
      * @notice Creates an arbitration proxy on the home chain.
      * @param _realitio Realitio contract address.
      * @param _metadata Metadata for Realitio.
-     * @param _foreignProxy Address of the proxy on L1.
+     * @param _foreignProxy Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
      * @param _foreignChainId The ID of foreign chain (Sepolia/Mainnet).
      */
     constructor(IRealitio _realitio, string memory _metadata, address _foreignProxy, uint256 _foreignChainId) {

--- a/contracts/src/0.8/RealitioHomeProxyGnosis.sol
+++ b/contracts/src/0.8/RealitioHomeProxyGnosis.sol
@@ -26,6 +26,7 @@ contract RealitioHomeProxyGnosis is IHomeArbitrationProxy {
     IAMB public immutable amb;
 
     /// @dev Address of the counter-party proxy on the Foreign Chain. TRUSTED.
+    /// Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
     address public immutable foreignProxy;
 
     /// @dev The chain ID where the foreign proxy is deployed.
@@ -65,7 +66,7 @@ contract RealitioHomeProxyGnosis is IHomeArbitrationProxy {
      * @notice Creates an arbitration proxy on the home chain.
      * @param _realitio Realitio contract address.
      * @param _metadata Metadata for Realitio.
-     * @param _foreignProxy The address of the proxy.
+     * @param _foreignProxy The address of the proxy. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
      * @param _foreignChainId The ID of the chain where the foreign proxy is deployed.
      * @param _amb ArbitraryMessageBridge contract address.
      */

--- a/contracts/src/0.8/RealitioHomeProxyOptimism.sol
+++ b/contracts/src/0.8/RealitioHomeProxyOptimism.sol
@@ -23,7 +23,8 @@ contract RealitioHomeProxyOptimism is IHomeArbitrationProxy {
 
     /// @dev The address of the Realitio contract (v3.0 required). TRUSTED.
     IRealitio public immutable realitio;
-    address public immutable foreignProxy; // Address of the proxy on L1.
+    /// @dev Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
+    address public immutable foreignProxy;
 
     /// @dev ID of the foreign chain, required for Realitio.
     bytes32 public immutable foreignChainId;
@@ -61,7 +62,7 @@ contract RealitioHomeProxyOptimism is IHomeArbitrationProxy {
      * @notice Creates an arbitration proxy on the home chain.
      * @param _realitio Realitio contract address.
      * @param _metadata Metadata for Realitio.
-     * @param _foreignProxy Address of the proxy on L1.
+     * @param _foreignProxy Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
      * @param _foreignChainId The ID of foreign chain (Sepolia/Mainnet).
      */
     constructor(IRealitio _realitio, string memory _metadata, address _foreignProxy, uint256 _foreignChainId) {

--- a/contracts/src/0.8/RealitioHomeProxyZkSync.sol
+++ b/contracts/src/0.8/RealitioHomeProxyZkSync.sol
@@ -27,7 +27,8 @@ contract RealitioHomeProxyZkSync is IHomeArbitrationProxy {
     /// @dev The address of the Realitio contract (v3.0 required). TRUSTED.
     IRealitio public immutable realitio;
     address public immutable foreignProxyAlias; // Address of the proxy on L1 converted to L2. See https://era.zksync.io/docs/api/go/utils.html#applyl1tol2alias
-    address public immutable foreignProxy; // Address of the proxy on L1. Required for Realitio UI.
+    /// @dev Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
+    address public immutable foreignProxy;
     /// @dev ID of the foreign chain, required for Realitio.
     bytes32 public immutable foreignChainId;
 
@@ -64,7 +65,7 @@ contract RealitioHomeProxyZkSync is IHomeArbitrationProxy {
      * @notice Creates an arbitration proxy on the home chain.
      * @param _realitio Realitio contract address.
      * @param _metadata Metadata for Realitio.
-     * @param _foreignProxy Address of the proxy on L1.
+     * @param _foreignProxy Address of the proxy on L1. Note that it needs to be precomputed before deployment by using deployer's address and tx nonce.
      * @param _foreignProxyAlias Alias of the proxy on L1.
      * @param _foreignChainId The ID of foreign chain (Sepolia/Mainnet).
      */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced inline documentation across several contracts to clarify that proxy addresses must be precomputed using the deployer’s address and transaction nonce before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->