### PR TITLE
fix(Proxies): review fixes

### DIFF
--- a/contracts/deploy/foreign/gnosis.js
+++ b/contracts/deploy/foreign/gnosis.js
@@ -23,6 +23,7 @@ async function deployForeignProxy({
   homeNetworkName,
   homeChainId,
   homeProxy,
+  wNative,
   arbitrator,
   courts,
   multipliers,
@@ -35,7 +36,7 @@ async function deployForeignProxy({
   return await deploy("RealitioForeignProxyGnosis", {
     contract: "src/0.8/RealitioForeignProxyGnosis.sol:RealitioForeignProxyGnosis",
     from,
-    args: [arbitrator, arbitratorExtraData, metaEvidence, ...multipliers, homeProxy, homeChainId, foreignAmb],
+    args: [wNative, arbitrator, arbitratorExtraData, metaEvidence, ...multipliers, homeProxy, homeChainId, foreignAmb],
     log: true,
     gas: 8000000,
   });

--- a/contracts/deploy/foreign/polygon.js
+++ b/contracts/deploy/foreign/polygon.js
@@ -24,6 +24,7 @@ async function deployForeignProxy({
   parameters,
   homeNetworkName,
   homeProxy,
+  wNative,
   arbitrator,
   courts,
   multipliers,
@@ -33,7 +34,7 @@ async function deployForeignProxy({
   const arbitratorExtraData = encodeExtraData(courts.oracle, numberOfJurors);
   const deployed = await deploy("RealitioForeignProxyPolygon", {
     from,
-    args: [arbitrator, arbitratorExtraData, metaEvidence, ...multipliers, checkpointManager, fxRoot],
+    args: [wNative, arbitrator, arbitratorExtraData, metaEvidence, ...multipliers, checkpointManager, fxRoot],
     log: true,
     gas: 8000000,
   });

--- a/contracts/deploy/shared/chains.js
+++ b/contracts/deploy/shared/chains.js
@@ -1,5 +1,5 @@
-const hardhatConfig = require("../../hardhat.config.js");
-const zkSyncConfig = require("../../hardhat.config.zksync.js");
+const hardhatConfig = require("../../hardhat.config.ts").default;
+const zkSyncConfig = require("../../hardhat.config.zksync.ts").default;
 
 // Deep merge rather than spread which is a shallow merge
 function deepMerge(target, source) {

--- a/contracts/src/0.8/RealitioHomeProxyArbitrum.sol
+++ b/contracts/src/0.8/RealitioHomeProxyArbitrum.sol
@@ -74,8 +74,8 @@ contract RealitioHomeProxyArbitrum is IHomeArbitrationProxy {
     constructor(IRealitio _realitio, string memory _metadata, address _foreignProxy, uint256 _foreignChainId) {
         realitio = _realitio;
         metadata = _metadata;
-        foreignChainId = bytes32(_foreignChainId);
         foreignProxy = _foreignProxy;
+        foreignChainId = bytes32(_foreignChainId);
     }
 
     /**

--- a/contracts/src/0.8/RealitioHomeProxyZkSync.sol
+++ b/contracts/src/0.8/RealitioHomeProxyZkSync.sol
@@ -234,6 +234,10 @@ contract RealitioHomeProxyZkSync is IHomeArbitrationProxy {
         emit ArbitrationFinished(_questionID);
     }
 
+    /**
+     * @notice Sends a message to L1.
+     * @param _data The data sent.
+     */
     function sendToL1(bytes memory _data) internal virtual {
         L1_MESSENGER_CONTRACT.sendToL1(_data);
     }

--- a/contracts/src/0.8/test/polygon/MockRealitioForeignProxyPolygon.sol
+++ b/contracts/src/0.8/test/polygon/MockRealitioForeignProxyPolygon.sol
@@ -9,6 +9,7 @@ import {RealitioForeignProxyPolygon} from "../../RealitioForeignProxyPolygon.sol
  */
 contract MockRealitioForeignProxyPolygon is RealitioForeignProxyPolygon {
     constructor(
+        address _wNative,
         IArbitrator _arbitrator,
         bytes memory _arbitratorExtraData,
         string memory _metaEvidence,
@@ -19,6 +20,7 @@ contract MockRealitioForeignProxyPolygon is RealitioForeignProxyPolygon {
         address _fxRoot
     )
         RealitioForeignProxyPolygon(
+            _wNative,
             _arbitrator,
             _arbitratorExtraData,
             _metaEvidence,

--- a/contracts/test/foreign-proxy-arbitrum.test.ts
+++ b/contracts/test/foreign-proxy-arbitrum.test.ts
@@ -889,6 +889,9 @@ describe("Cross-chain arbitration with appeals", () => {
       "The balance of the requester should stay the same (withdraw 0 round from winning ruling)"
     );
 
+    // Relay the ruling to check that withdrawals are still possible.
+    await foreignProxy.connect(other).relayRule(questionID, await requester.getAddress(), { value: l2GasPrice });
+
     await foreignProxy.withdrawFeesAndRewards(arbitrationID, crowdfunder1Address, 0, 50);
 
     newBalance1 = await getBalance(crowdfunder1);

--- a/contracts/test/foreign-proxy-gnosis.test.ts
+++ b/contracts/test/foreign-proxy-gnosis.test.ts
@@ -73,6 +73,7 @@ describe("Cross-chain arbitration with appeals", () => {
     expect(await foreignProxy.arbitratorExtraData()).to.equal(arbitratorExtraData);
     expect(await foreignProxy.homeProxy()).to.equal(homeProxy.target);
     expect(await foreignProxy.homeChainId()).to.equal(homeChainId);
+    expect(await foreignProxy.wNative()).to.equal(other);
     expect(await homeProxy.metadata()).to.equal(metadata);
 
     // 0 - winner, 1 - loser, 2 - loserAppealPeriod.
@@ -725,6 +726,7 @@ describe("Cross-chain arbitration with appeals", () => {
     });
 
     const foreignProxy = await ForeignProxy.deploy(
+      other, // Use other address as placeholder for wNative
       arbitrator.target,
       arbitratorExtraData,
       metaEvidence,

--- a/contracts/test/foreign-proxy-gnosis.test.ts
+++ b/contracts/test/foreign-proxy-gnosis.test.ts
@@ -107,6 +107,30 @@ describe("Cross-chain arbitration with appeals", () => {
     ).to.be.revertedWith("Arbitration already requested");
   });
 
+  it("Should set correct values when requesting arbitration with custom parameters and fire the event", async () => {
+    await expect(
+      foreignProxy.connect(requester).requestArbitrationCustomParameters(questionID, maxPrevious, 500, { value: arbitrationCost - 1 })
+    ).to.be.revertedWith("Deposit value too low");
+
+    await expect(
+      foreignProxy.connect(requester).requestArbitrationCustomParameters(questionID, maxPrevious, 500, { value: arbitrationCost })
+    )
+      .to.emit(realitio, "MockNotifyOfArbitrationRequest")
+      .withArgs(questionID, await requester.getAddress())
+      .to.emit(homeProxy, "RequestNotified")
+      .withArgs(questionID, await requester.getAddress(), maxPrevious)
+      .to.emit(foreignProxy, "ArbitrationRequested")
+      .withArgs(questionID, await requester.getAddress(), maxPrevious);
+
+    const arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
+    expect(arbitration[0]).to.equal(1, "Incorrect status of the arbitration after creating a request");
+    expect(arbitration[1]).to.equal(1000, "Deposit value stored incorrectly");
+
+    await expect(
+      foreignProxy.connect(requester).requestArbitrationCustomParameters(questionID, maxPrevious, 500, { value: arbitrationCost })
+    ).to.be.revertedWith("Arbitration already requested");
+  });
+
   it("Should set correct values when acknowledging arbitration and create a dispute", async () => {
     await foreignProxy.connect(requester).requestArbitration(questionID, maxPrevious, { value: oneETH }); // Deliberately overpay
     const oldBalance = await getBalance(requester);
@@ -205,7 +229,7 @@ describe("Cross-chain arbitration with appeals", () => {
       .withArgs(questionID, await requester.getAddress());
 
     let arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
-    expect(arbitration[0]).to.equal(4, "Status should be Failed");
+    expect(arbitration[0]).to.equal(5, "Status should be Failed");
 
     await expect(foreignProxy.handleFailedDisputeCreation(questionID, await requester.getAddress()))
       .to.emit(realitio, "MockCancelArbitrationRequest")
@@ -219,8 +243,53 @@ describe("Cross-chain arbitration with appeals", () => {
     expect(newBalance).to.equal(oldBalance + toBigInt(arbitrationCost), "Requester was not reimbursed correctly");
 
     arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
-    expect(arbitration[0]).to.equal(0, "Status should be empty");
+    expect(arbitration[0]).to.equal(5, "Status should not change");
     expect(arbitration[1]).to.equal(0, "Deposit should be empty");
+
+    // Home proxy won't allow to send msg 2nd time but foreign proxy checks should pass.
+    await expect(
+      foreignProxy.connect(other).handleFailedDisputeCreation(questionID, await requester.getAddress())
+    ).to.be.revertedWith("Failed to call contract");
+  });
+
+  it("Should correctly handle failed dispute creation with custom parameters", async () => {
+    await foreignProxy.connect(requester).requestArbitration(questionID, maxPrevious, { value: arbitrationCost });
+
+    const oldBalance = await getBalance(requester);
+    await expect(foreignProxy.handleFailedDisputeCreationCustomParameters(questionID, await requester.getAddress(), 1000)).to.be.revertedWith(
+      "Invalid arbitration status"
+    );
+
+    await arbitrator.setArbitrationPrice(2000); // Increase the cost so creation fails.
+
+    await expect(homeProxy.handleNotifiedRequest(questionID, await requester.getAddress()))
+      .to.emit(foreignProxy, "ArbitrationFailed")
+      .withArgs(questionID, await requester.getAddress())
+      .to.emit(homeProxy, "RequestAcknowledged")
+      .withArgs(questionID, await requester.getAddress());
+
+    let arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
+    expect(arbitration[0]).to.equal(5, "Status should be Failed");
+
+    await expect(foreignProxy.handleFailedDisputeCreationCustomParameters(questionID, await requester.getAddress(), 1000))
+      .to.emit(realitio, "MockCancelArbitrationRequest")
+      .withArgs(questionID)
+      .to.emit(homeProxy, "ArbitrationFailed")
+      .withArgs(questionID, await requester.getAddress())
+      .to.emit(foreignProxy, "ArbitrationCanceled")
+      .withArgs(questionID, await requester.getAddress());
+
+    const newBalance = await getBalance(requester);
+    expect(newBalance).to.equal(oldBalance + toBigInt(arbitrationCost), "Requester was not reimbursed correctly");
+
+    arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
+    expect(arbitration[0]).to.equal(5, "Status should not change");
+    expect(arbitration[1]).to.equal(0, "Deposit should be empty");
+
+    // Home proxy won't allow to send msg 2nd time but foreign proxy checks should pass.
+    await expect(
+      foreignProxy.connect(other).handleFailedDisputeCreationCustomParameters(questionID, await requester.getAddress(), 1000)
+    ).to.be.revertedWith("Failed to call contract");
   });
 
   it("Should handle the ruling correctly", async () => {
@@ -231,21 +300,78 @@ describe("Cross-chain arbitration with appeals", () => {
 
     const arbAnswer = zeroPadValue(toBeHex(7), 32);
 
+    await expect(foreignProxy.connect(other).relayRule(questionID, await requester.getAddress())).to.be.revertedWith(
+      "Dispute not resolved"
+    );
+
     await expect(arbitrator.giveRuling(2, 8))
-      .to.emit(homeProxy, "ArbitratorAnswered")
-      .withArgs(questionID, arbAnswer)
       .to.emit(foreignProxy, "Ruling")
       .withArgs(arbitrator.target, 2, 8);
 
-    const arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
+    let arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
     expect(arbitration[0]).to.equal(3, "Status should be Ruled");
     expect(arbitration[3]).to.equal(8, "Stored answer is incorrect");
+
+    await expect(foreignProxy.connect(other).relayRule(questionID, await requester.getAddress()))
+      .to.emit(foreignProxy, "RulingRelayed")
+      .withArgs(questionID, arbAnswer)
+      .to.emit(homeProxy, "ArbitratorAnswered")
+      .withArgs(questionID, arbAnswer);
+
+    arbitration = await foreignProxy.arbitrationRequests(arbitrationID, await requester.getAddress());
+    expect(arbitration[0]).to.equal(4, "Status should be Relayed");
 
     await expect(homeProxy.reportArbitrationAnswer(questionID, ZERO_HASH, ZERO_HASH, ZeroAddress))
       .to.emit(realitio, "MockFinalize")
       .withArgs(questionID, arbAnswer)
       .to.emit(homeProxy, "ArbitrationFinished")
       .withArgs(questionID);
+
+    // Home proxy won't allow to send msg 2nd time but foreign proxy checks should pass.
+    await expect(foreignProxy.connect(other).relayRule(questionID, await requester.getAddress())).to.be.revertedWith(
+      "Failed to call contract"
+    );
+  });
+
+  it("Should handle the ruling correctly using custom parameters", async () => {
+    await foreignProxy.connect(requester).requestArbitration(questionID, maxPrevious, { value: arbitrationCost });
+
+    await homeProxy.handleNotifiedRequest(questionID, await requester.getAddress());
+    await expect(foreignProxy.rule(2, 8)).to.be.revertedWith("Only arbitrator allowed");
+
+    const arbAnswer = zeroPadValue(toBeHex(7), 32);
+
+    await expect(foreignProxy.connect(other).relayRuleCustomParameters(questionID, await requester.getAddress(), 1000)).to.be.revertedWith(
+      "Dispute not resolved"
+    );
+
+    await expect(arbitrator.giveRuling(2, 8))
+      .to.emit(foreignProxy, "Ruling")
+      .withArgs(arbitrator.target, 2, 8);
+
+    let arbitration = await foreignProxy.arbitrationRequests(0, await requester.getAddress());
+    expect(arbitration[0]).to.equal(3, "Status should be Ruled");
+    expect(arbitration[3]).to.equal(8, "Stored answer is incorrect");
+
+    await expect(foreignProxy.connect(other).relayRuleCustomParameters(questionID, await requester.getAddress(), 1000))
+      .to.emit(foreignProxy, "RulingRelayed")
+      .withArgs(questionID, arbAnswer)
+      .to.emit(homeProxy, "ArbitratorAnswered")
+      .withArgs(questionID, arbAnswer);
+
+    arbitration = await foreignProxy.arbitrationRequests(arbitrationID, await requester.getAddress());
+    expect(arbitration[0]).to.equal(4, "Status should be Relayed");
+
+    await expect(homeProxy.reportArbitrationAnswer(questionID, ZERO_HASH, ZERO_HASH, ZeroAddress))
+      .to.emit(realitio, "MockFinalize")
+      .withArgs(questionID, arbAnswer)
+      .to.emit(homeProxy, "ArbitrationFinished")
+      .withArgs(questionID);
+
+    // Home proxy won't allow to send msg 2nd time but foreign proxy checks should pass.
+    await expect(foreignProxy.connect(other).relayRuleCustomParameters(questionID, await requester.getAddress(), 1000)).to.be.revertedWith(
+      "Failed to call contract"
+    );
   });
 
   it("Should correctly fund an appeal and fire the events", async () => {
@@ -479,6 +605,8 @@ describe("Cross-chain arbitration with appeals", () => {
       "The balance of the requester should stay the same (withdraw 0 round from winning ruling)"
     );
 
+    // Relay the ruling to check that withdrawals are still possible.
+    await foreignProxy.connect(other).relayRule(questionID, await requester.getAddress());
     await foreignProxy.withdrawFeesAndRewards(arbitrationID, crowdfunder1Address, 0, 50);
 
     newBalance1 = await getBalance(crowdfunder1);

--- a/contracts/test/foreign-proxy-optimism.test.ts
+++ b/contracts/test/foreign-proxy-optimism.test.ts
@@ -749,6 +749,9 @@ describe("Cross-chain arbitration with appeals", () => {
       "The balance of the requester should stay the same (withdraw 0 round from winning ruling)"
     );
 
+    // Relay the ruling to check that withdrawals are still possible.
+    await foreignProxy.connect(other).relayRule(questionID, await requester.getAddress());
+
     await foreignProxy.withdrawFeesAndRewards(arbitrationID, crowdfunder1Address, 0, 50);
 
     newBalance1 = await getBalance(crowdfunder1);

--- a/contracts/test/foreign-proxy-polygon.test.ts
+++ b/contracts/test/foreign-proxy-polygon.test.ts
@@ -62,6 +62,7 @@ describe("Cross-chain arbitration with appeals", () => {
     expect(await foreignProxy.arbitrator()).to.equal(arbitrator.target);
     expect(await foreignProxy.arbitratorExtraData()).to.equal(arbitratorExtraData);
     expect(await foreignProxy.fxChildTunnel()).to.equal(homeProxy.target);
+    expect(await foreignProxy.wNative()).to.equal(other);
     expect(await homeProxy.metadata()).to.equal(metadata);
     expect(await homeProxy.foreignChainId()).to.equal(zeroPadValue(toBeHex(5), 32));
     expect(await homeProxy.foreignProxy()).to.equal(foreignProxy.target);
@@ -703,6 +704,7 @@ describe("Cross-chain arbitration with appeals", () => {
     const HomeProxy = await ethers.getContractFactory("MockRealitioHomeProxyPolygon", signer);
 
     const foreignProxy = await ForeignProxy.deploy(
+      other, // Use other address as placeholder for wNative
       arbitrator.target,
       arbitratorExtraData,
       metaEvidence,

--- a/contracts/test/foreign-proxy-zksync.test.ts
+++ b/contracts/test/foreign-proxy-zksync.test.ts
@@ -960,6 +960,10 @@ describe("Cross-chain arbitration with appeals", () => {
     oldBalance2 = await getBalance(crowdfunder2);
 
     // Withdraw 0 round.
+
+    // Relay the ruling to check that withdrawals are still possible.
+    await foreignProxy.connect(other).relayRule(questionID, await requester.getAddress(), { value: l2GasPrice });
+  
     await foreignProxy.withdrawFeesAndRewards(arbitrationID, requesterAddress, 0, 50);
 
     newBalance = await getBalance(requester);


### PR DESCRIPTION
Note that Polygon bridge doesn't have any parameters so custom bridging functions weren't added there

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for wrapped native tokens (wNative) across Gnosis, Polygon, Arbitrum, Optimism, and zkSync foreign proxy contracts, improving native token handling and safety.
  - Introduced new relay functions to allow rulings to be explicitly relayed to the home proxy, with new statuses tracking relayed rulings.
  - Added functions allowing custom gas parameterization for cross-chain arbitration requests and ruling relays on Gnosis.

- **Improvements**
  - Enhanced security and reliability of native token transfers by replacing direct ETH sends with safer transfer methods.
  - Broadened withdrawal eligibility to include relayed rulings.
  - Improved documentation and comments for better clarity on contract behavior and answer formats.

- **Bug Fixes**
  - Ensured that repeated or unauthorized relay and failed dispute calls are properly rejected.
  - Updated status handling to prevent blocking and allow multiple relay attempts where appropriate.

- **Tests**
  - Expanded test coverage for new relay functions, wNative integration, and custom parameter scenarios.
  - Added and updated assertions to reflect new statuses and behaviors, ensuring withdrawals remain possible after relaying rulings.

- **Chores**
  - Updated deployment scripts and mock contracts to support wNative parameters.
  - Adjusted import paths for configuration files to improve compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->