### PR TITLE
fix(Proxies): add custom to arbitrum fee function

### DIFF
--- a/contracts/src/0.8/RealitioForeignProxyArbitrum.sol
+++ b/contracts/src/0.8/RealitioForeignProxyArbitrum.sol
@@ -694,7 +694,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
 
         // Taken from here https://docs.arbitrum.io/for-devs/troubleshooting-building#what-is-a-retryable-tickets-submission-fee-how-can-i-calculate-it-what-happens-if-i-the-fee-i-provide-is-insufficient
         uint256 maxSubmissionCost = inbox.calculateRetryableSubmissionFee(data.length, BLOCK_BASE_FEE);
-        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost);
+        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost, _parameters[0], _parameters[1]); // l2GasLimit and gasPriceBid respectively.
         uint256 arbitrationCost = arbitrator.arbitrationCost(arbitratorExtraData);
         require(msg.value >= arbitrationCost + arbitrumFee, "Deposit value too low");
 
@@ -729,7 +729,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
         bytes memory data = abi.encodeWithSelector(methodSelector, _questionID, _requester);
 
         uint256 maxSubmissionCost = inbox.calculateRetryableSubmissionFee(data.length, BLOCK_BASE_FEE);
-        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost);
+        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost, _parameters[0], _parameters[1]); // l2GasLimit and gasPriceBid respectively.
         require(msg.value >= arbitrumFee, "Should cover arbitrum fee");
         uint256 deposit = _arbitration.deposit;
 
@@ -772,7 +772,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
         bytes memory data = abi.encodeWithSelector(methodSelector, _questionID, bytes32(realitioRuling));
 
         uint256 maxSubmissionCost = inbox.calculateRetryableSubmissionFee(data.length, BLOCK_BASE_FEE);
-        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost);
+        uint256 arbitrumFee = arbitrumGasFee(maxSubmissionCost, _parameters[0], _parameters[1]); // l2GasLimit and gasPriceBid respectively.
         require(msg.value >= arbitrumFee, "Should cover arbitrum fee");
 
         _arbitration.status = Status.Relayed;
@@ -801,9 +801,15 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
      * is greater than or equal to maxSubmissionCost + l2CallValue + gasLimit * maxFeePerGas.
      * https://docs.arbitrum.io/how-arbitrum-works/l1-to-l2-messaging
      * @param _maxSubmissionCost Cost to calculate a retryable ticket on L1.
+     * @param _l2GasLimit Gas limit for tx on L2.
+     * @param _gasPriceBid Gas price bid for tx on L2.
      * @return arbitrumFee Total arbitrum fee required to pass a message L1->L2.
      */
-    function arbitrumGasFee(uint256 _maxSubmissionCost) private view returns (uint256 arbitrumFee) {
-        arbitrumFee = _maxSubmissionCost + L2_CALL_VALUE + l2GasLimit * gasPriceBid;
+    function arbitrumGasFee(
+        uint256 _maxSubmissionCost,
+        uint256 _l2GasLimit,
+        uint256 _gasPriceBid
+    ) private view returns (uint256 arbitrumFee) {
+        arbitrumFee = _maxSubmissionCost + L2_CALL_VALUE + _l2GasLimit * _gasPriceBid;
     }
 }

--- a/contracts/test/foreign-proxy-arbitrum.test.ts
+++ b/contracts/test/foreign-proxy-arbitrum.test.ts
@@ -171,7 +171,7 @@ describe("Cross-chain arbitration with appeals", () => {
 
     const arbitration = await foreignProxy.arbitrationRequests(arbitrationID, await requester.getAddress());
     expect(arbitration[0]).to.equal(1, "Incorrect status of the arbitration after creating a request");
-    expect(arbitration[1]).to.equal(8500, "Deposit value stored incorrectly"); // Surplus (20000) + ArbCost (1000) - ArbitrumFee (10000 + 5*500).
+    expect(arbitration[1]).to.equal(10950, "Deposit value stored incorrectly"); // Surplus (20000) + ArbCost (1000) - ArbitrumFee (10000 + 5*10).
 
     // Inbox acts as foreignProxyAlias here so it passes onlyForeignProxyAlias require
     await expect(mockInbox.connect(other).redeemTicket(0))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now specify custom L2 gas limit and gas price bid parameters for Arbitrum retryable ticket fee calculations, allowing for more flexible fee management.

- **Bug Fixes**
  - Updated deposit calculations in arbitration requests to accurately reflect the new dynamic Arbitrum fee computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->