### PR TITLE
fix(PolygonProxy): add home proxy getter

### DIFF
--- a/contracts/src/0.8/RealitioForeignProxyPolygon.sol
+++ b/contracts/src/0.8/RealitioForeignProxyPolygon.sol
@@ -618,6 +618,13 @@ contract RealitioForeignProxyPolygon is IForeignArbitrationProxy, IDisputeResolv
         return disputeIDToDisputeDetails[_externalDisputeID].arbitrationID;
     }
 
+    /**  
+     * @notice Returns the address of the home proxy.
+     * @return Home proxy address.
+     */
+    function homeProxy() external view override returns (address) {
+        return fxChildTunnel;
+    }
     // **************************** //
     // *         Internal         * //
     // **************************** //

--- a/contracts/src/0.8/interfaces/IArbitrationProxies.sol
+++ b/contracts/src/0.8/interfaces/IArbitrationProxies.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.25;
 
 import {IArbitrable} from "@kleros/erc-792/contracts/IArbitrable.sol";
 import {IEvidence} from "@kleros/erc-792/contracts/erc-1497/IEvidence.sol";
+import {IRealitio} from "./IRealitio.sol";
 
 interface IHomeArbitrationProxy {
     /**
@@ -116,6 +117,12 @@ interface IHomeArbitrationProxy {
      *  @dev Template_hashes won't be used by this home proxy. 
      */
     function metadata() external view returns (string calldata);
+
+    /**
+     * @notice Returns the address of Reality instance.
+     * @return Realitio address.
+     */
+    function realitio() external view returns (IRealitio);
 }
 
 interface IForeignArbitrationProxy {
@@ -192,4 +199,17 @@ interface IForeignArbitrationProxy {
      * @return The fee to create a dispute.
      */
     function getDisputeFee(bytes32 _questionID) external view returns (uint256);
+
+    /**
+     * @notice Returns the address of the home proxy.
+     * @return Home proxy address.
+     */
+    function homeProxy() external view returns (address);
+
+    /**
+     * @notice Returns the creation block of the dispute.
+     * @param _disputeID the ID of the dispute.
+     * @return Block number of dispute creation.
+     */
+    function arbitrationCreatedBlock(uint256 _disputeID) external view returns (uint256);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only getters to arbitration proxies for improved transparency and integration:
    * View the home proxy address on the Polygon foreign proxy.
    * Retrieve the linked Realitio contract on the home proxy.
    * Access the home proxy address and the block number when a dispute was created on the foreign proxy.
* **Documentation**
  * Added inline documentation for the new public getters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->