### PR TITLE
docs(Proxies): add a comment about aliasing

### DIFF
--- a/contracts/src/0.8/RealitioForeignProxyArbitrum.sol
+++ b/contracts/src/0.8/RealitioForeignProxyArbitrum.sol
@@ -179,7 +179,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
      * @param _maxPrevious The maximum value of the current bond for the question. The arbitration request will get rejected if the current bond is greater than _maxPrevious. If set to 0, _maxPrevious is ignored.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _gasPriceBid Gas price bid for tx on L2.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function requestArbitrationCustomParameters(
         bytes32 _questionID,
@@ -280,7 +280,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
      * @param _requester The address of the arbitration requester.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _gasPriceBid Gas price bid for tx on L2.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function handleFailedDisputeCreationCustomParameters(
         bytes32 _questionID,
@@ -490,7 +490,7 @@ contract RealitioForeignProxyArbitrum is IForeignArbitrationProxy, IDisputeResol
      * @param _requester The address of the arbitration requester.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _gasPriceBid Gas price bid for tx on L2.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function relayRuleCustomParameters(
         bytes32 _questionID,

--- a/contracts/src/0.8/RealitioForeignProxyZkSync.sol
+++ b/contracts/src/0.8/RealitioForeignProxyZkSync.sol
@@ -175,7 +175,7 @@ contract RealitioForeignProxyZkSync is IForeignArbitrationProxy, IDisputeResolve
      * @param _maxPrevious The maximum value of the current bond for the question. The arbitration request will get rejected if the current bond is greater than _maxPrevious. If set to 0, _maxPrevious is ignored.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _l2GasPerPubdataByteLimit L2 gas price for each published L1 calldata byte.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function requestArbitrationCustomParameters(
         bytes32 _questionID,
@@ -301,7 +301,7 @@ contract RealitioForeignProxyZkSync is IForeignArbitrationProxy, IDisputeResolve
      * @param _requester The address of the arbitration requester.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _l2GasPerPubdataByteLimit L2 gas price for each published L1 calldata byte.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function handleFailedDisputeCreationCustomParameters(
         bytes32 _questionID,
@@ -504,7 +504,7 @@ contract RealitioForeignProxyZkSync is IForeignArbitrationProxy, IDisputeResolve
      * @param _requester The address of the arbitration requester.
      * @param _l2GasLimit Gas limit for tx on L2.
      * @param _l2GasPerPubdataByteLimit L2 gas price for each published L1 calldata byte.
-     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds.
+     * @param _excessFeeRefundAddress The address on L2 to receive gas refunds. Note that refund address should be EOA and not smart contract or EIP-7702 address, otherwise it will be aliased on L2.
      */
     function relayRuleCustomParameters(
         bytes32 _questionID,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contract documentation to clarify that excess fee refund addresses must be externally owned accounts (EOAs) and cannot be smart contracts or EIP-7702 addresses to prevent aliasing on Layer 2 networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->